### PR TITLE
Update configuration to be Terraform workspace specific

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,29 @@
 
 [![GitHub Build Status](https://github.com/cisagov/cool-assessment-images-manager-iam/workflows/build/badge.svg)](https://github.com/cisagov/cool-assessment-images-manager-iam/actions)
 
-This is a generic skeleton project that can be used to quickly get a
-new [cisagov](https://github.com/cisagov) [Terraform
-module](https://www.terraform.io/docs/modules/index.html) GitHub
-repository started.  This skeleton project contains [licensing
-information](LICENSE), as well as [pre-commit
-hooks](https://pre-commit.com) and
-[GitHub Actions](https://github.com/features/actions) configurations
-appropriate for the major languages that we use.
+This project is used to manage IAM permissions for COOL users that are allowed
+to manage the objects stored in the S3 bucket created in
+[cisagov/cool-images-assessment-images](https://github.com/cisagov/cool-images-assessment-images).
 
-See [here](https://www.terraform.io/docs/modules/index.html) for more
-details on Terraform modules and the standard module structure.
+## Pre-requisites ##
+
+- [Terraform](https://www.terraform.io/) installed on your system.
+- An accessible AWS S3 bucket to store Terraform state
+  (specified in [backend.tf](backend.tf)).
+- An accessible AWS DynamoDB database to store the Terraform state lock
+  (specified in [backend.tf](backend.tf)).
+- Access to all of the Terraform remote states specified in
+  [remote_states.tf](remote_states.tf).
+- The following COOL accounts and roles must have been created:
+  - Users:
+    [`cisagov/cool-accounts/users`](https://github.com/cisagov/cool-accounts/tree/develop/users)
+- User accounts for all users must have been created previously. We
+  recommend using the
+  [`cisagov/cool-users-non-admin`](https://github.com/cisagov/cool-users-non-admin)
+  repository to create users.
+- Terraform in
+  [`cisagov/cool-images-assessment-images`](https://github.com/cisagov/cool-images-assessment-images)
+  must have been applied.
 
 ## Usage ##
 

--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ details on Terraform modules and the standard module structure.
   variables (see [Inputs](#Inputs) below for details):
 
   ```hcl
-  users = {
-    "firstname1.lastname1" = ["production", "staging"],
-    "firstname2.lastname2" = ["production"],
-    "firstname3.lastname3" = ["staging"]
-  }
+  users = []
+    "firstname1.lastname1",
+    "firstname2.lastname2",
+    "firstname3.lastname3",
+  ]
   ```
 
 1. Run the command `terraform init`.
@@ -57,15 +57,11 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_iam_group.assessment_images_managers](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_group) | resource |
-| [aws_iam_group_policy_attachment.assume_images_assessmentimagesbucketfullaccess_role_production_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_group_policy_attachment) | resource |
-| [aws_iam_group_policy_attachment.assume_images_assessmentimagesbucketfullaccess_role_staging_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_group_policy_attachment) | resource |
-| [aws_iam_policy.assume_images_assessmentimagesbucketfullaccess_role_production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.assume_images_assessmentimagesbucketfullaccess_role_staging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_user_group_membership.assessment_images_managers_production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_group_membership) | resource |
-| [aws_iam_user_group_membership.assessment_images_managers_staging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_group_membership) | resource |
+| [aws_iam_group_policy_attachment.assume_images_assessmentimagesbucketfullaccess_role_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_group_policy_attachment) | resource |
+| [aws_iam_policy.assume_images_assessmentimagesbucketfullaccess_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_user_group_membership.assessment_images_managers](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_group_membership) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
-| [aws_iam_policy_document.assume_images_assessmentimagesbucketfullaccess_role_production_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.assume_images_assessmentimagesbucketfullaccess_role_staging_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.assume_images_assessmentimagesbucketfullaccess_role_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_user.users](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_user) | data source |
 | [terraform_remote_state.assessment_images](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 | [terraform_remote_state.users](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
@@ -74,12 +70,12 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| assessment\_images\_managers\_group\_name | The base name of the group to be created for assessment images manager users in each Images account. This value has the environment name appended to it for each environment. | `string` | `"assessment_images_managers"` | no |
+| assessment\_images\_managers\_group\_name | The base name of the group to be created for assessment images manager users in each Images account. This value has the current workspace name appended to it before use. | `string` | `"assessment_images_managers"` | no |
 | assume\_images\_assessmentimagesbucketfullaccess\_policy\_description | The description to associate with the IAM policy that allows assumption of the role that allows full access to the assessment images bucket in an Images account. | `string` | `"The IAM policy that allows assumption of the role that allows full access to the assessment images bucket in an Images account."` | no |
-| assume\_images\_assessmentimagesbucketfullaccess\_policy\_name | The base name to assign the IAM policies that allow assumption of the role that allows full access to the assessment images bucket in an Images account. This value has the environment name appended to it for each environment. | `string` | `"Images-AssumeAssessmentImagesBucketFullAccess"` | no |
+| assume\_images\_assessmentimagesbucketfullaccess\_policy\_name | The base name to assign the IAM policies that allow assumption of the role that allows full access to the assessment images bucket in an Images account. This value has the current workspace name appended to it before use. | `string` | `"Images-AssumeAssessmentImagesBucketFullAccess"` | no |
 | aws\_region | The AWS region to deploy into (e.g. us-east-1). | `string` | `"us-east-1"` | no |
 | tags | Tags to apply to all AWS resources created. | `map(string)` | `{}` | no |
-| users | A map whose keys are the usernames of each user that is allowed to manage assessment images and whose values are lists of the environments each respective user can manage. Example: { "firstname1.lastname1" = ["production", "staging"], "firstname2.lastname2" = ["production"], "firstname3.lastname3" = ["staging"] } | `map(list(string))` | n/a | yes |
+| users | A list whose values are the usernames of each user that is allowed to manage assessment images. Example: ["firstname1.lastname1", "firstname2.lastname2", "firstname3.lastname3"] | `list(string)` | n/a | yes |
 
 ## Outputs ##
 

--- a/assume_images_assessmentimagesbucketfullaccess_role.tf
+++ b/assume_images_assessmentimagesbucketfullaccess_role.tf
@@ -1,6 +1,6 @@
 # IAM policy document that allows assumption of the
-# AssessmentImagesBucketFullAccess role in the Images (Production) account
-data "aws_iam_policy_document" "assume_images_assessmentimagesbucketfullaccess_role_production_doc" {
+# AssessmentImagesBucketFullAccess role in the Images account.
+data "aws_iam_policy_document" "assume_images_assessmentimagesbucketfullaccess_role_doc" {
   statement {
     effect = "Allow"
 
@@ -10,56 +10,23 @@ data "aws_iam_policy_document" "assume_images_assessmentimagesbucketfullaccess_r
     ]
 
     resources = [
-      data.terraform_remote_state.assessment_images.outputs.assessmentimagesbucketfullaccess_role_production.arn,
+      data.terraform_remote_state.assessment_images.outputs.assessmentimagesbucketfullaccess_role.arn,
     ]
   }
 }
 
-resource "aws_iam_policy" "assume_images_assessmentimagesbucketfullaccess_role_production" {
+resource "aws_iam_policy" "assume_images_assessmentimagesbucketfullaccess_role" {
   provider = aws.users
 
   description = var.assume_images_assessmentimagesbucketfullaccess_policy_description
-  name        = local.assume_assessmentimagesbucketfullaccess_policy_name["production"]
-  policy      = data.aws_iam_policy_document.assume_images_assessmentimagesbucketfullaccess_role_production_doc.json
+  name        = local.assume_assessmentimagesbucketfullaccess_policy_name
+  policy      = data.aws_iam_policy_document.assume_images_assessmentimagesbucketfullaccess_role_doc.json
 }
 
 # Attach the policy to the Production assessment images managers group
-resource "aws_iam_group_policy_attachment" "assume_images_assessmentimagesbucketfullaccess_role_production_attachment" {
+resource "aws_iam_group_policy_attachment" "assume_images_assessmentimagesbucketfullaccess_role_attachment" {
   provider = aws.users
 
-  group      = aws_iam_group.assessment_images_managers["production"].name
-  policy_arn = aws_iam_policy.assume_images_assessmentimagesbucketfullaccess_role_production.arn
-}
-
-# IAM policy document that allows assumption of the
-# AssessmentImagesBucketFullAccess role in the Images (Staging) account
-data "aws_iam_policy_document" "assume_images_assessmentimagesbucketfullaccess_role_staging_doc" {
-  statement {
-    effect = "Allow"
-
-    actions = [
-      "sts:AssumeRole",
-      "sts:TagSession",
-    ]
-
-    resources = [
-      data.terraform_remote_state.assessment_images.outputs.assessmentimagesbucketfullaccess_role_staging.arn,
-    ]
-  }
-}
-
-resource "aws_iam_policy" "assume_images_assessmentimagesbucketfullaccess_role_staging" {
-  provider = aws.users
-
-  description = var.assume_images_assessmentimagesbucketfullaccess_policy_description
-  name        = local.assume_assessmentimagesbucketfullaccess_policy_name["staging"]
-  policy      = data.aws_iam_policy_document.assume_images_assessmentimagesbucketfullaccess_role_staging_doc.json
-}
-
-# Attach the policy to the Staging assessment images managers group
-resource "aws_iam_group_policy_attachment" "assume_images_assessmentimagesbucketfullaccess_role_staging_attachment" {
-  provider = aws.users
-
-  group      = aws_iam_group.assessment_images_managers["staging"].name
-  policy_arn = aws_iam_policy.assume_images_assessmentimagesbucketfullaccess_role_staging.arn
+  group      = aws_iam_group.assessment_images_managers.name
+  policy_arn = aws_iam_policy.assume_images_assessmentimagesbucketfullaccess_role.arn
 }

--- a/group_membership.tf
+++ b/group_membership.tf
@@ -1,24 +1,12 @@
 # Put assessment images manager users in the appropriate group
-resource "aws_iam_user_group_membership" "assessment_images_managers_production" {
+resource "aws_iam_user_group_membership" "assessment_images_managers" {
   provider = aws.users
 
-  for_each = local.assessment_images_managers["production"]
+  for_each = local.users
 
   user = data.aws_iam_user.users[each.value].user_name
 
   groups = [
-    aws_iam_group.assessment_images_managers["production"].name
-  ]
-}
-
-resource "aws_iam_user_group_membership" "assessment_images_managers_staging" {
-  provider = aws.users
-
-  for_each = local.assessment_images_managers["staging"]
-
-  user = data.aws_iam_user.users[each.value].user_name
-
-  groups = [
-    aws_iam_group.assessment_images_managers["staging"].name
+    aws_iam_group.assessment_images_managers.name
   ]
 }

--- a/groups.tf
+++ b/groups.tf
@@ -2,7 +2,5 @@
 resource "aws_iam_group" "assessment_images_managers" {
   provider = aws.users
 
-  for_each = local.assessment_images_managers_group_name
-
-  name = each.value
+  name = local.assessment_images_managers_group_name
 }

--- a/locals.tf
+++ b/locals.tf
@@ -12,17 +12,12 @@ locals {
   # as assume role session names.
   caller_user_name = split("/", data.aws_caller_identity.current.arn)[1]
 
-  # The list of environments to support in this configuration
-  system_environments = ["production", "staging"]
+  # Create the assessment images managers group name.
+  assessment_images_managers_group_name = format("%s-%s", var.assessment_images_managers_group_name, terraform.workspace)
 
-  # Create the assessment images managers group name for each system environment.
-  assessment_images_managers_group_name = { for e in local.system_environments : e => format("%s-%s", var.assessment_images_managers_group_name, e) }
+  # Create the AssessmentImagesBucketFullAccess assumption policy name.
+  assume_assessmentimagesbucketfullaccess_policy_name = format("%s-%s", var.assume_images_assessmentimagesbucketfullaccess_policy_name, terraform.workspace)
 
-  # Create the AssessmentImagesBucketFullAccess assumption policy names for each
-  # system environment
-  assume_assessmentimagesbucketfullaccess_policy_name = { for e in local.system_environments : e => format("%s-%s", var.assume_images_assessmentimagesbucketfullaccess_policy_name, e) }
-
-  # Create a map whose keys are each system environment and its values are a list
-  # of users to give access to in that environment.
-  assessment_images_managers = { for e in local.system_environments : e => toset([for u, a in var.users : u if contains(a, e)]) }
+  # Get the unique values in var.users.
+  users = toset(var.users)
 }

--- a/remote_states.tf
+++ b/remote_states.tf
@@ -16,7 +16,7 @@ data "terraform_remote_state" "assessment_images" {
     key            = "cool-images-assessment-images/terraform.tfstate"
   }
 
-  workspace = "default"
+  workspace = terraform.workspace
 }
 
 data "terraform_remote_state" "users" {

--- a/users.tf
+++ b/users.tf
@@ -1,8 +1,8 @@
-# Fetch all users listed in var.production_users and var.staging_users
+# Fetch all users listed var.users
 data "aws_iam_user" "users" {
   provider = aws.users
 
-  for_each = toset(keys(var.users))
+  for_each = local.users
 
-  user_name = each.key
+  user_name = each.value
 }

--- a/variables.tf
+++ b/variables.tf
@@ -5,8 +5,8 @@
 # ------------------------------------------------------------------------------
 
 variable "users" {
-  type        = map(list(string))
-  description = "A map whose keys are the usernames of each user that is allowed to manage assessment images and whose values are lists of the environments each respective user can manage. Example: { \"firstname1.lastname1\" = [\"production\", \"staging\"], \"firstname2.lastname2\" = [\"production\"], \"firstname3.lastname3\" = [\"staging\"] }"
+  type        = list(string)
+  description = "A list whose values are the usernames of each user that is allowed to manage assessment images. Example: [\"firstname1.lastname1\", \"firstname2.lastname2\", \"firstname3.lastname3\"]"
 }
 
 # ------------------------------------------------------------------------------
@@ -17,7 +17,7 @@ variable "users" {
 
 variable "assessment_images_managers_group_name" {
   type        = string
-  description = "The base name of the group to be created for assessment images manager users in each Images account. This value has the environment name appended to it for each environment."
+  description = "The base name of the group to be created for assessment images manager users in each Images account. This value has the current workspace name appended to it before use."
   default     = "assessment_images_managers"
 }
 
@@ -29,7 +29,7 @@ variable "assume_images_assessmentimagesbucketfullaccess_policy_description" {
 
 variable "assume_images_assessmentimagesbucketfullaccess_policy_name" {
   type        = string
-  description = "The base name to assign the IAM policies that allow assumption of the role that allows full access to the assessment images bucket in an Images account. This value has the environment name appended to it for each environment."
+  description = "The base name to assign the IAM policies that allow assumption of the role that allows full access to the assessment images bucket in an Images account. This value has the current workspace name appended to it before use."
   default     = "Images-AssumeAssessmentImagesBucketFullAccess"
 }
 


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request separates this configuration to be specific to its Terraform workspace instead of explicitly containing configuration for our Production and Staging environments. This closes #2.

It also updates the README to have an accurate project description and include pre-requisites which were missed in #1.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

When https://github.com/cisagov/cool-images-assessment-images/pull/17 is merged it will no longer be a monolithic configuration for the buckets that store assessment images. This allows us to break this configuration down to a workspace specific implementation. This also aligns with the goal of completely separating our Production and Staging environments. 
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
