### PR TITLE
Support new COOL environment structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ __pycache__
 .terraform.lock.hcl
 terraform.tfstate
 terraform.tfstate.backup
+*.tfconfig
 *.tfvars

--- a/README.md
+++ b/README.md
@@ -2,36 +2,67 @@
 
 [![GitHub Build Status](https://github.com/cisagov/cool-assessment-images-manager-iam/workflows/build/badge.svg)](https://github.com/cisagov/cool-assessment-images-manager-iam/actions)
 
-This is a generic skeleton project that can be used to quickly get a
-new [cisagov](https://github.com/cisagov) [Terraform
-module](https://www.terraform.io/docs/modules/index.html) GitHub
-repository started.  This skeleton project contains [licensing
-information](LICENSE), as well as [pre-commit
-hooks](https://pre-commit.com) and
-[GitHub Actions](https://github.com/features/actions) configurations
-appropriate for the major languages that we use.
+This is a Terraform deployment for creating IAM resources for those
+users allowed to manage assessment images in the COOL.
 
-See [here](https://www.terraform.io/docs/modules/index.html) for more
-details on Terraform modules and the standard module structure.
+## Pre-requisites ##
+
+- [Terraform](https://www.terraform.io/) installed on your system.
+- An accessible AWS S3 bucket to store Terraform state (specified in
+  [backend.tf](backend.tf)).
+- An accessible AWS DynamoDB database to store the Terraform state lock
+  (specified in [backend.tf](backend.tf)).
+- Access to all of the Terraform remote states specified in
+  [remote_states.tf](remote_states.tf).
+- User accounts for all users must have been created previously.  We recommend
+  using the
+  [`cisagov/cool-users-non-admin`](https://github.com/cisagov/cool-users-non-admin)
+  repository to create users.
 
 ## Usage ##
 
+The following steps show how to use this Terraform code in an environment named
+"dev".
+
+1. Create a backend configuration file named `dev.tfconfig` containing the name
+of the bucket where Terraform state is stored for that environment.  This file
+is required to initialize the Terraform backend in each environment:
+
+    ```hcl
+    bucket = "my-dev-terraform-state-bucket"
+    ```
+
+1. Initialize the Terraform backend for the "dev" environment using your backend
+   configuration file:
+
+    ```console
+    terraform init -backend-config=dev.tfconfig
+    ```
+
+    > [!NOTE]
+    > When performing this step for additional environments (i.e. not your first
+    > environment), use the `-reconfigure` flag:
+    >
+    > ```console
+    > terraform init -backend-config=other-env.tfconfig -reconfigure
+    > ```
+
 1. Create a Terraform workspace (if you haven't already done so) by running
-   `terraform workspace new <workspace_name>`
-1. Create a `<workspace_name>.tfvars` file with all of the required
-  variables (see [Inputs](#inputs) below for details):
+   `terraform workspace new dev`.
+1. Create a `dev.tfvars` file with all of the required variables (see
+  [Inputs](#inputs) below for details):
 
   ```hcl
-  users = {
-    "firstname1.lastname1" = ["production", "staging"],
-    "firstname2.lastname2" = ["production"],
-    "firstname3.lastname3" = ["staging"]
-  }
+  terraform_state_bucket = "my-dev-terraform-state-bucket"
+
+  users = [
+    "firstname1.lastname1",
+    "firstname2.lastname2",
+    "firstname3.lastname3",
+  ]
   ```
 
-1. Run the command `terraform init`.
-1. Run the command `terraform apply
-  -var-file=<workspace_name>.tfvars`.
+1. Run the command `terraform apply -var-file=dev.tfvars`.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements ##
@@ -58,15 +89,11 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_iam_group.assessment_images_managers](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_group) | resource |
-| [aws_iam_group_policy_attachment.assume_images_assessmentimagesbucketfullaccess_role_production_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_group_policy_attachment) | resource |
-| [aws_iam_group_policy_attachment.assume_images_assessmentimagesbucketfullaccess_role_staging_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_group_policy_attachment) | resource |
-| [aws_iam_policy.assume_images_assessmentimagesbucketfullaccess_role_production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.assume_images_assessmentimagesbucketfullaccess_role_staging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_user_group_membership.assessment_images_managers_production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_group_membership) | resource |
-| [aws_iam_user_group_membership.assessment_images_managers_staging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_group_membership) | resource |
+| [aws_iam_group_policy_attachment.assume_images_assessmentimagesbucketfullaccess_role_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_group_policy_attachment) | resource |
+| [aws_iam_policy.assume_images_assessmentimagesbucketfullaccess_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_user_group_membership.assessment_images_managers](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_group_membership) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
-| [aws_iam_policy_document.assume_images_assessmentimagesbucketfullaccess_role_production_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.assume_images_assessmentimagesbucketfullaccess_role_staging_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.assume_images_assessmentimagesbucketfullaccess_role_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_user.users](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_user) | data source |
 | [terraform_remote_state.assessment_images](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 | [terraform_remote_state.users](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
@@ -75,12 +102,13 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| assessment\_images\_managers\_group\_name | The base name of the group to be created for assessment images manager users in each Images account. This value has the environment name appended to it for each environment. | `string` | `"assessment_images_managers"` | no |
+| assessment\_images\_managers\_group\_name | The name of the group to be created for assessment images manager users in the Images account. | `string` | `"assessment_images_managers"` | no |
 | assume\_images\_assessmentimagesbucketfullaccess\_policy\_description | The description to associate with the IAM policy that allows assumption of the role that allows full access to the assessment images bucket in an Images account. | `string` | `"The IAM policy that allows assumption of the role that allows full access to the assessment images bucket in an Images account."` | no |
-| assume\_images\_assessmentimagesbucketfullaccess\_policy\_name | The base name to assign the IAM policies that allow assumption of the role that allows full access to the assessment images bucket in an Images account. This value has the environment name appended to it for each environment. | `string` | `"Images-AssumeAssessmentImagesBucketFullAccess"` | no |
+| assume\_images\_assessmentimagesbucketfullaccess\_policy\_name | The name to assign the IAM policy that allows assumption of the role that allows full access to the assessment images bucket in the Images account. | `string` | `"Images-AssumeAssessmentImagesBucketFullAccess"` | no |
 | aws\_region | The AWS region to deploy into (e.g. us-east-1). | `string` | `"us-east-1"` | no |
 | tags | Tags to apply to all AWS resources created. | `map(string)` | `{}` | no |
-| users | A map whose keys are the usernames of each user that is allowed to manage assessment images and whose values are lists of the environments each respective user can manage. Example: { "firstname1.lastname1" = ["production", "staging"], "firstname2.lastname2" = ["production"], "firstname3.lastname3" = ["staging"] } | `map(list(string))` | n/a | yes |
+| terraform\_state\_bucket | The name of the S3 bucket where Terraform state is stored. | `string` | n/a | yes |
+| users | A list of usernames that are allowed to manage assessment images. Example: [ "firstname1.lastname1", "firstname2.lastname2", "firstname3.lastname3" ] | `list(string)` | n/a | yes |
 
 ## Outputs ##
 

--- a/assume_images_assessmentimagesbucketfullaccess_role.tf
+++ b/assume_images_assessmentimagesbucketfullaccess_role.tf
@@ -1,6 +1,6 @@
 # IAM policy document that allows assumption of the
-# AssessmentImagesBucketFullAccess role in the Images (Production) account
-data "aws_iam_policy_document" "assume_images_assessmentimagesbucketfullaccess_role_production_doc" {
+# AssessmentImagesBucketFullAccess role in the Images account
+data "aws_iam_policy_document" "assume_images_assessmentimagesbucketfullaccess_role_doc" {
   statement {
     actions = [
       "sts:AssumeRole",
@@ -8,54 +8,23 @@ data "aws_iam_policy_document" "assume_images_assessmentimagesbucketfullaccess_r
     ]
     effect = "Allow"
     resources = [
-      data.terraform_remote_state.assessment_images.outputs.assessmentimagesbucketfullaccess_role_production.arn,
+      data.terraform_remote_state.assessment_images.outputs.assessmentimagesbucketfullaccess_role.arn,
     ]
   }
 }
 
-resource "aws_iam_policy" "assume_images_assessmentimagesbucketfullaccess_role_production" {
+resource "aws_iam_policy" "assume_images_assessmentimagesbucketfullaccess_role" {
   provider = aws.users
 
   description = var.assume_images_assessmentimagesbucketfullaccess_policy_description
-  name        = local.assume_assessmentimagesbucketfullaccess_policy_name["production"]
-  policy      = data.aws_iam_policy_document.assume_images_assessmentimagesbucketfullaccess_role_production_doc.json
+  name        = var.assume_images_assessmentimagesbucketfullaccess_policy_name
+  policy      = data.aws_iam_policy_document.assume_images_assessmentimagesbucketfullaccess_role_doc.json
 }
 
-# Attach the policy to the Production assessment images managers group
-resource "aws_iam_group_policy_attachment" "assume_images_assessmentimagesbucketfullaccess_role_production_attachment" {
+# Attach the policy to the assessment images managers group
+resource "aws_iam_group_policy_attachment" "assume_images_assessmentimagesbucketfullaccess_role_attachment" {
   provider = aws.users
 
-  group      = aws_iam_group.assessment_images_managers["production"].name
-  policy_arn = aws_iam_policy.assume_images_assessmentimagesbucketfullaccess_role_production.arn
-}
-
-# IAM policy document that allows assumption of the
-# AssessmentImagesBucketFullAccess role in the Images (Staging) account
-data "aws_iam_policy_document" "assume_images_assessmentimagesbucketfullaccess_role_staging_doc" {
-  statement {
-    actions = [
-      "sts:AssumeRole",
-      "sts:TagSession",
-    ]
-    effect = "Allow"
-    resources = [
-      data.terraform_remote_state.assessment_images.outputs.assessmentimagesbucketfullaccess_role_staging.arn,
-    ]
-  }
-}
-
-resource "aws_iam_policy" "assume_images_assessmentimagesbucketfullaccess_role_staging" {
-  provider = aws.users
-
-  description = var.assume_images_assessmentimagesbucketfullaccess_policy_description
-  name        = local.assume_assessmentimagesbucketfullaccess_policy_name["staging"]
-  policy      = data.aws_iam_policy_document.assume_images_assessmentimagesbucketfullaccess_role_staging_doc.json
-}
-
-# Attach the policy to the Staging assessment images managers group
-resource "aws_iam_group_policy_attachment" "assume_images_assessmentimagesbucketfullaccess_role_staging_attachment" {
-  provider = aws.users
-
-  group      = aws_iam_group.assessment_images_managers["staging"].name
-  policy_arn = aws_iam_policy.assume_images_assessmentimagesbucketfullaccess_role_staging.arn
+  group      = aws_iam_group.assessment_images_managers.name
+  policy_arn = aws_iam_policy.assume_images_assessmentimagesbucketfullaccess_role.arn
 }

--- a/backend.tf
+++ b/backend.tf
@@ -1,10 +1,14 @@
 terraform {
   backend "s3" {
-    encrypt        = true
-    bucket         = "cisa-cool-terraform-state"
+    # Use a partial configuration to avoid hardcoding the bucket name. This
+    # allows the bucket name to be set on a per-environment basis via the
+    # -backend-config command line option or other methods.  For details, see:
+    # https://developer.hashicorp.com/terraform/language/backend#partial-configuration
+    bucket         = ""
     dynamodb_table = "terraform-state-lock"
+    encrypt        = true
+    key            = "cool-assessment-images-manager-iam/terraform.tfstate"
     profile        = "cool-terraform-backend"
     region         = "us-east-1"
-    key            = "cool-assessment-images-manager-iam/terraform.tfstate"
   }
 }

--- a/group_membership.tf
+++ b/group_membership.tf
@@ -1,22 +1,11 @@
 # Put assessment images manager users in the appropriate group
-resource "aws_iam_user_group_membership" "assessment_images_managers_production" {
+resource "aws_iam_user_group_membership" "assessment_images_managers" {
   provider = aws.users
 
-  for_each = local.assessment_images_managers["production"]
+  for_each = toset(var.users)
 
   groups = [
-    aws_iam_group.assessment_images_managers["production"].name
+    aws_iam_group.assessment_images_managers.name
   ]
-  user = data.aws_iam_user.users[each.value].user_name
-}
-
-resource "aws_iam_user_group_membership" "assessment_images_managers_staging" {
-  provider = aws.users
-
-  for_each = local.assessment_images_managers["staging"]
-
-  groups = [
-    aws_iam_group.assessment_images_managers["staging"].name
-  ]
-  user = data.aws_iam_user.users[each.value].user_name
+  user = data.aws_iam_user.users[each.key].user_name
 }

--- a/groups.tf
+++ b/groups.tf
@@ -1,8 +1,6 @@
-# An IAM group for assessment images managers in the Images accounts.
+# An IAM group for assessment images managers in the Images account.
 resource "aws_iam_group" "assessment_images_managers" {
   provider = aws.users
 
-  for_each = local.assessment_images_managers_group_name
-
-  name = each.value
+  name = var.assessment_images_managers_group_name
 }

--- a/locals.tf
+++ b/locals.tf
@@ -11,18 +11,4 @@ locals {
   # Extract the user name of the current caller for use
   # as assume role session names.
   caller_user_name = split("/", data.aws_caller_identity.current.arn)[1]
-
-  # The list of environments to support in this configuration
-  system_environments = ["production", "staging"]
-
-  # Create the assessment images managers group name for each system environment.
-  assessment_images_managers_group_name = { for e in local.system_environments : e => format("%s-%s", var.assessment_images_managers_group_name, e) }
-
-  # Create the AssessmentImagesBucketFullAccess assumption policy names for each
-  # system environment
-  assume_assessmentimagesbucketfullaccess_policy_name = { for e in local.system_environments : e => format("%s-%s", var.assume_images_assessmentimagesbucketfullaccess_policy_name, e) }
-
-  # Create a map whose keys are each system environment and its values are a list
-  # of users to give access to in that environment.
-  assessment_images_managers = { for e in local.system_environments : e => toset([for u, a in var.users : u if contains(a, e)]) }
 }

--- a/remote_states.tf
+++ b/remote_states.tf
@@ -8,28 +8,28 @@ data "terraform_remote_state" "assessment_images" {
   backend = "s3"
 
   config = {
-    encrypt        = true
-    bucket         = "cisa-cool-terraform-state"
+    bucket         = var.terraform_state_bucket
     dynamodb_table = "terraform-state-lock"
+    encrypt        = true
+    key            = "cool-images-assessment-images/terraform.tfstate"
     profile        = "cool-terraform-backend"
     region         = "us-east-1"
-    key            = "cool-images-assessment-images/terraform.tfstate"
   }
 
-  workspace = "default"
+  workspace = terraform.workspace
 }
 
 data "terraform_remote_state" "users" {
   backend = "s3"
 
   config = {
-    encrypt        = true
-    bucket         = "cisa-cool-terraform-state"
+    bucket         = var.terraform_state_bucket
     dynamodb_table = "terraform-state-lock"
+    encrypt        = true
+    key            = "cool-accounts/users.tfstate"
     profile        = "cool-terraform-backend"
     region         = "us-east-1"
-    key            = "cool-accounts/users.tfstate"
   }
 
-  workspace = "production"
+  workspace = terraform.workspace
 }

--- a/users.tf
+++ b/users.tf
@@ -1,8 +1,8 @@
-# Fetch all users listed in var.production_users and var.staging_users
+# Fetch all users listed in var.users
 data "aws_iam_user" "users" {
   provider = aws.users
 
-  for_each = toset(keys(var.users))
+  for_each = toset(var.users)
 
   user_name = each.key
 }

--- a/variables.tf
+++ b/variables.tf
@@ -6,6 +6,7 @@
 
 variable "terraform_state_bucket" {
   description = "The name of the S3 bucket where Terraform state is stored."
+  nullable    = false
   type        = string
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,11 @@
 # You must provide a value for each of these parameters.
 # ------------------------------------------------------------------------------
 
+variable "terraform_state_bucket" {
+  description = "The name of the S3 bucket where Terraform state is stored."
+  type        = string
+}
+
 variable "users" {
   description = "A map whose keys are the usernames of each user that is allowed to manage assessment images and whose values are lists of the environments each respective user can manage. Example: { \"firstname1.lastname1\" = [\"production\", \"staging\"], \"firstname2.lastname2\" = [\"production\"], \"firstname3.lastname3\" = [\"staging\"] }"
   nullable    = false

--- a/variables.tf
+++ b/variables.tf
@@ -11,9 +11,9 @@ variable "terraform_state_bucket" {
 }
 
 variable "users" {
-  description = "A map whose keys are the usernames of each user that is allowed to manage assessment images and whose values are lists of the environments each respective user can manage. Example: { \"firstname1.lastname1\" = [\"production\", \"staging\"], \"firstname2.lastname2\" = [\"production\"], \"firstname3.lastname3\" = [\"staging\"] }"
+  description = "A list of usernames that are allowed to manage assessment images. Example: [ \"firstname1.lastname1\", \"firstname2.lastname2\", \"firstname3.lastname3\" ]"
   nullable    = false
-  type        = map(list(string))
+  type        = list(string)
 }
 
 # ------------------------------------------------------------------------------
@@ -24,7 +24,7 @@ variable "users" {
 
 variable "assessment_images_managers_group_name" {
   default     = "assessment_images_managers"
-  description = "The base name of the group to be created for assessment images manager users in each Images account. This value has the environment name appended to it for each environment."
+  description = "The name of the group to be created for assessment images manager users in the Images account."
   nullable    = false
   type        = string
 }
@@ -38,7 +38,7 @@ variable "assume_images_assessmentimagesbucketfullaccess_policy_description" {
 
 variable "assume_images_assessmentimagesbucketfullaccess_policy_name" {
   default     = "Images-AssumeAssessmentImagesBucketFullAccess"
-  description = "The base name to assign the IAM policies that allow assumption of the role that allows full access to the assessment images bucket in an Images account. This value has the environment name appended to it for each environment."
+  description = "The name to assign the IAM policy that allows assumption of the role that allows full access to the assessment images bucket in the Images account."
   nullable    = false
   type        = string
 }


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR makes updates in support of the switchover from our legacy account/environment scheme (where staging and production accounts exist within the same AWS organization) to our new scheme (where they do not).

Highlights include:
* Removal of hard-coded references to production and staging resources
* Use of [partial backend configurations](https://developer.hashicorp.com/terraform/language/backend#partial-configuration)
* Changing `var.users` from a map (specifying which environments the user is allowed to managed) to a simpler list of usernames

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The goal of this PR is to get us closer to our modernized account scheme where there is no more co-mingling of staging and production accounts.  Doing that will result in cleaner code across all COOL-related repositories as well as improved separation of resources across all COOL environments. 

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I successfully applied this updated Terraform in dev-a, staging-a, and production environments and everything looks as expected.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
